### PR TITLE
Removed multiplying px value

### DIFF
--- a/Assets/FluidSimulation/Shaders/FulidSimulation.compute
+++ b/Assets/FluidSimulation/Shaders/FulidSimulation.compute
@@ -100,7 +100,7 @@ void UpdateAdvection(uint2 id : SV_DispatchThreadID)
     float2 uv = float2(id.x / w, id.y / h) + px.xy * 0.5;
 
     float2 velocity = _UpdateVelocity.SampleLevel(_LinearClamp, uv, 0).xy;
-    float2 result = _SourceVelocity.SampleLevel(_LinearClamp, uv - velocity * _DeltaTime * px.xy, 0).xy;
+    float2 result = _SourceVelocity.SampleLevel(_LinearClamp, uv - velocity * _DeltaTime, 0).xy;
 
     _ResultVelocity[id] = float4(result, 0.0, 1.0) * _Scale;
 }


### PR DESCRIPTION
Multiplying px value to the velocity is wrong. I removed it. I can see the result more natural.